### PR TITLE
[FINAL] Don't reset values on upgrade.

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -337,39 +337,31 @@ static const NSInteger kRateAlertViewTag        = 1001;
 	{
 		trackingVersion = version;
 		[userDefaults setObject:version forKey:kAppiraterCurrentVersion];
+        [userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:kAppiraterFirstUseDate];
+        [userDefaults setInteger:0 forKey:kAppiraterUseCount];
+        [userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
+        [userDefaults setBool:NO forKey:kAppiraterRated];
+        [userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+        [userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
 	}
 	
 	if (_debug)
 		NSLog(@"APPIRATER Tracking version: %@", trackingVersion);
 	
-	if ([trackingVersion isEqualToString:version])
-	{
-		// check if the first use date has been set. if not, set it.
-		NSTimeInterval timeInterval = [userDefaults doubleForKey:kAppiraterFirstUseDate];
-		if (timeInterval == 0)
-		{
-			timeInterval = [[NSDate date] timeIntervalSince1970];
-			[userDefaults setDouble:timeInterval forKey:kAppiraterFirstUseDate];
-		}
-		
-		// increment the use count
-		NSInteger useCount = [userDefaults integerForKey:kAppiraterUseCount];
-		useCount++;
-		[userDefaults setInteger:useCount forKey:kAppiraterUseCount];
-		if (_debug)
-			NSLog(@"APPIRATER Use count: %@", @(useCount));
-	}
-	else
-	{
-		// it's a new version of the app, so restart tracking
-		[userDefaults setObject:version forKey:kAppiraterCurrentVersion];
-		[userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:kAppiraterFirstUseDate];
-		[userDefaults setInteger:1 forKey:kAppiraterUseCount];
-		[userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
-		[userDefaults setBool:NO forKey:kAppiraterRated];
-		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
-		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
-	}
+    // check if the first use date has been set. if not, set it.
+    NSTimeInterval timeInterval = [userDefaults doubleForKey:kAppiraterFirstUseDate];
+    if (timeInterval == 0)
+    {
+        timeInterval = [[NSDate date] timeIntervalSince1970];
+        [userDefaults setDouble:timeInterval forKey:kAppiraterFirstUseDate];
+    }
+    
+    // increment the use count
+    NSInteger useCount = [userDefaults integerForKey:kAppiraterUseCount];
+    useCount++;
+    [userDefaults setInteger:useCount forKey:kAppiraterUseCount];
+    if (_debug)
+        NSLog(@"APPIRATER Use count: %@", @(useCount));
 	
 	[userDefaults synchronize];
 }
@@ -385,39 +377,32 @@ static const NSInteger kRateAlertViewTag        = 1001;
 	{
 		trackingVersion = version;
 		[userDefaults setObject:version forKey:kAppiraterCurrentVersion];
+        [userDefaults setDouble:0 forKey:kAppiraterFirstUseDate];
+        [userDefaults setInteger:0 forKey:kAppiraterUseCount];
+        [userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
+        [userDefaults setBool:NO forKey:kAppiraterRated];
+        [userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+        [userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
 	}
 	
 	if (_debug)
 		NSLog(@"APPIRATER Tracking version: %@", trackingVersion);
 	
-	if ([trackingVersion isEqualToString:version])
-	{
-		// check if the first use date has been set. if not, set it.
-		NSTimeInterval timeInterval = [userDefaults doubleForKey:kAppiraterFirstUseDate];
-		if (timeInterval == 0)
-		{
-			timeInterval = [[NSDate date] timeIntervalSince1970];
-			[userDefaults setDouble:timeInterval forKey:kAppiraterFirstUseDate];
-		}
-		
-		// increment the significant event count
-		NSInteger sigEventCount = [userDefaults integerForKey:kAppiraterSignificantEventCount];
-		sigEventCount++;
-		[userDefaults setInteger:sigEventCount forKey:kAppiraterSignificantEventCount];
-		if (_debug)
-			NSLog(@"APPIRATER Significant event count: %@", @(sigEventCount));
-	}
-	else
-	{
-		// it's a new version of the app, so restart tracking
-		[userDefaults setObject:version forKey:kAppiraterCurrentVersion];
-		[userDefaults setDouble:0 forKey:kAppiraterFirstUseDate];
-		[userDefaults setInteger:0 forKey:kAppiraterUseCount];
-		[userDefaults setInteger:1 forKey:kAppiraterSignificantEventCount];
-		[userDefaults setBool:NO forKey:kAppiraterRated];
-		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
-		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
-	}
+    // check if the first use date has been set. if not, set it.
+    NSTimeInterval timeInterval = [userDefaults doubleForKey:kAppiraterFirstUseDate];
+    if (timeInterval == 0)
+    {
+        timeInterval = [[NSDate date] timeIntervalSince1970];
+        [userDefaults setDouble:timeInterval forKey:kAppiraterFirstUseDate];
+    }
+    
+    // increment the significant event count
+    NSInteger sigEventCount = [userDefaults integerForKey:kAppiraterSignificantEventCount];
+    sigEventCount++;
+    [userDefaults setInteger:sigEventCount forKey:kAppiraterSignificantEventCount];
+
+    if (_debug)
+        NSLog(@"APPIRATER Significant event count: %@", @(sigEventCount));
 	
 	[userDefaults synchronize];
 }

--- a/Appirater.m
+++ b/Appirater.m
@@ -337,12 +337,12 @@ static const NSInteger kRateAlertViewTag        = 1001;
 	{
 		trackingVersion = version;
 		[userDefaults setObject:version forKey:kAppiraterCurrentVersion];
-        [userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:kAppiraterFirstUseDate];
-        [userDefaults setInteger:0 forKey:kAppiraterUseCount];
-        [userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
-        [userDefaults setBool:NO forKey:kAppiraterRated];
-        [userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
-        [userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
+		[userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:kAppiraterFirstUseDate];
+		[userDefaults setInteger:0 forKey:kAppiraterUseCount];
+		[userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
+		[userDefaults setBool:NO forKey:kAppiraterRated];
+		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
 	}
 	
 	if (_debug)
@@ -377,12 +377,12 @@ static const NSInteger kRateAlertViewTag        = 1001;
 	{
 		trackingVersion = version;
 		[userDefaults setObject:version forKey:kAppiraterCurrentVersion];
-        [userDefaults setDouble:0 forKey:kAppiraterFirstUseDate];
-        [userDefaults setInteger:0 forKey:kAppiraterUseCount];
-        [userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
-        [userDefaults setBool:NO forKey:kAppiraterRated];
-        [userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
-        [userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
+		[userDefaults setDouble:0 forKey:kAppiraterFirstUseDate];
+		[userDefaults setInteger:0 forKey:kAppiraterUseCount];
+		[userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
+		[userDefaults setBool:NO forKey:kAppiraterRated];
+		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
 	}
 	
 	if (_debug)


### PR DESCRIPTION
- [x] @dmzza 

Current behavior is that tracking is reset everytime a user upgrades, this will revert this behavior.
