### PR TITLE
[FINAL][HOLD] update openURL: for iOS 10 / dropping iOS 9

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -602,7 +602,9 @@ static const NSInteger kRateAlertViewTag        = 1001;
 			reviewURL = [templateReviewURLiOS7 stringByReplacingOccurrencesOfString:@"APP_ID" withString:[NSString stringWithFormat:@"%@", _appId]];
 		}
 
-		[[UIApplication sharedApplication] openURL:[NSURL URLWithString:reviewURL]];
+        [UIApplication.sharedApplication openURL:[NSURL URLWithString:reviewURL]
+                                         options:@{}
+                               completionHandler:nil];
 		#endif
 	}
 }


### PR DESCRIPTION
If iOS 9 is dropped, then the old `openURL:` is a fatal in Xcode